### PR TITLE
Include selected file to output

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,17 +27,18 @@ function gulpSassInheritance(options) {
       var graph = sassGraph.parseDir(options.dir, options)
 
       _.forEach(files, function(file) {
-
+        var fullpaths = [];
+        
         if (graph.index && graph.index[file.path]) {
-          var fullpaths = graph.index[file.path].importedBy;
+          fullpaths = graph.index[file.path].importedBy;
 
           if (options.debug) {
             console.log('File', file.path);
             console.log(' - importedBy', fullpaths);
           }
-          filesPaths = _.union(filesPaths, fullpaths);
         }
-
+    	  fullpaths.push(file.path); // add file itself
+        filesPaths = _.union(filesPaths, fullpaths);
       });
 
       vfs.src(filesPaths)


### PR DESCRIPTION
Until now it only passed the array of files that depended on the file… but not the file itself. This basically made it impossible to generate a main.scss file if it no other file depends on it.

This new behavior is also how gulp-jade-inheritance works.