### PR TITLE
Update version for NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass-inheritance",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "Rebuild only changed sass/scss files and all it's dependencies",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Update version as NPM install is serving version before commit df9e157a57718eb7da259e682d1a7c0f3ef5b5e1

Why I think this is a major version change is that, before I noticed the fact this had been fixed I was planning to do 2 separate tasks or updates to the task to add my "parent" sass files also to the pipe. If somebody has done that, this will most likely break the backwards compatibility.
